### PR TITLE
Add threshold to maintainer

### DIFF
--- a/Maintainer.lua
+++ b/Maintainer.lua
@@ -10,12 +10,8 @@ while true do
  
     for item, config in pairs(items) do
         if itemsCrafting[k] ~= true then
-            local answer = ae2.requestItem(item, config[1], config[2])
-            if answer == true then
-                logInfo("Requested " .. item .. "x " .. config[2])
-            else
-                logInfo("Failed to request " .. item .. "x " .. config[2])
-            end
+            local success, answer = ae2.requestItem(item, config[1], config[2])
+            logInfo(answer)
         end
  
     end

--- a/Maintainer.lua
+++ b/Maintainer.lua
@@ -1,22 +1,22 @@
 local ae2 = require("src.AE2")
 local cfg = require("config")
-
+ 
 local items = cfg.items
 local sleepInterval = cfg.sleep
-
+ 
 while true do
     local itemsCrafting = ae2.checkIfCrafting()
-
-    for k, v in pairs(items) do
+ 
+    for item, config in pairs(items) do
         if itemsCrafting[k] ~= true then
-            local answer = ae2.requestItem(k, v)
+            local answer = ae2.requestItem(item, config[1], config[2])
             if answer == true then
-                print("[" .. os.date("%H:%M:%S") .. "] " .. "Requested " .. v .. "x " .. k)
+                print("[" .. os.date("%H:%M:%S") .. "] " .. "Requested " .. item .. "x " .. config[2])
             else
-                print("[" .. os.date("%H:%M:%S") .. "] " .. "Failed to request " .. v .. "x " .. k)
+                print("[" .. os.date("%H:%M:%S") .. "] " .. "Failed to request " .. item .. "x " .. config[2])
             end
         end
-
+ 
     end
     os.sleep(sleepInterval)
 end

--- a/Maintainer.lua
+++ b/Maintainer.lua
@@ -1,6 +1,7 @@
 local ae2 = require("src.AE2")
 local cfg = require("config")
- 
+local util = require("src.Utility") 
+
 local items = cfg.items
 local sleepInterval = cfg.sleep
  
@@ -11,9 +12,9 @@ while true do
         if itemsCrafting[k] ~= true then
             local answer = ae2.requestItem(item, config[1], config[2])
             if answer == true then
-                print("[" .. os.date("%H:%M:%S") .. "] " .. "Requested " .. item .. "x " .. config[2])
+                logInfo("Requested " .. item .. "x " .. config[2])
             else
-                print("[" .. os.date("%H:%M:%S") .. "] " .. "Failed to request " .. item .. "x " .. config[2])
+                logInfo("Failed to request " .. item .. "x " .. config[2])
             end
         end
  

--- a/Maintainer.lua
+++ b/Maintainer.lua
@@ -9,7 +9,7 @@ while true do
     local itemsCrafting = ae2.checkIfCrafting()
  
     for item, config in pairs(items) do
-        if itemsCrafting[k] ~= true then
+        if itemsCrafting[item] ~= true then
             local success, answer = ae2.requestItem(item, config[1], config[2])
             logInfo(answer)
         end

--- a/config.lua
+++ b/config.lua
@@ -1,8 +1,8 @@
 local cfg = {}
 
 cfg["items"] = {
-    ["drop of Molten SpaceTime"] = 1,
-    ["drop of Molten White Dwarf Matter"] = 1
+    ["drop of Molten SpaceTime"] = {1,1}
+    ["drop of Molten White Dwarf Matter"] = {1,1}
 }
 
 cfg["sleep"] = 10

--- a/src/AE2.lua
+++ b/src/AE2.lua
@@ -25,9 +25,9 @@ function AE2.requestItem(name, threshold, count)
                 os.sleep(1)
             end
             if craft.hasFailed() then
-                return table.unpack({false, "Failed to request " .. name .. "x " .. count})
+                return table.unpack({false, "Failed to request " .. name .. " x " .. count})
             else
-                return table.unpack({true, "Requested " .. name .. "x " .. count})
+                return table.unpack({true, "Requested " .. name .. " x " .. count})
             end
 
         end

--- a/src/AE2.lua
+++ b/src/AE2.lua
@@ -1,5 +1,4 @@
 local component = require("component")
-local util = require("src.Utility")
 local ME = component.me_interface
 
 local AE2 = {}
@@ -16,8 +15,7 @@ function AE2.requestItem(name, threshold, count)
                 ["label"] = name        
             })
             if (#itemInSystem > 0 and itemInSystem[1]["size"] > threshold) then 
-                logInfo("The amount of " .. itemInSystem[1]["label"] .. " exceeds threshold! Aborting request.")
-                return false
+                return table.unpack({false, "The amount of " .. itemInSystem[1]["label"] .. " exceeds threshold! Aborting request."})
             end
         end
         if item.label == name then
@@ -26,11 +24,15 @@ function AE2.requestItem(name, threshold, count)
             while craft.isComputing() == true do
                 os.sleep(1)
             end
-            return craft.hasFailed() == false
+            if craft.hasFailed() then
+                return table.unpack({false, "Failed to request " .. name .. "x " .. count})
+            else
+                return table.unpack({true, "Requested " .. name .. "x " .. count})
+            end
 
         end
     end
-    return nil
+    return table.unpack({false, name .. " is not craftable!"})
 end
 
 function  AE2.checkIfCrafting()

--- a/src/AE2.lua
+++ b/src/AE2.lua
@@ -10,12 +10,14 @@ function AE2.requestItem(name, threshold, count)
 
     if #craftables >= 1 then
         item = craftables[1].getItemStack()
-        itemInSystem = ME.getItemsInNetwork({
-        	["label"] = name        
-        })
-        if (#itemInSystem > 0 and itemInSystem[1]["size"] > threshold) then 
-            print("The amount of " .. itemInSystem[1]["label"] .. " exceeds threshold! Aborting request.")
-            return false
+        if threshold ~= nil then
+            itemInSystem = ME.getItemsInNetwork({
+                ["label"] = name        
+            })
+            if (#itemInSystem > 0 and itemInSystem[1]["size"] > threshold) then 
+                print("The amount of " .. itemInSystem[1]["label"] .. " exceeds threshold! Aborting request.")
+                return false
+            end
         end
         if item.label == name then
             local craft = craftables[1].request(count)

--- a/src/AE2.lua
+++ b/src/AE2.lua
@@ -1,4 +1,5 @@
 local component = require("component")
+local util = require("src.Utility")
 local ME = component.me_interface
 
 local AE2 = {}
@@ -15,7 +16,7 @@ function AE2.requestItem(name, threshold, count)
                 ["label"] = name        
             })
             if (#itemInSystem > 0 and itemInSystem[1]["size"] > threshold) then 
-                print("The amount of " .. itemInSystem[1]["label"] .. " exceeds threshold! Aborting request.")
+                logInfo("The amount of " .. itemInSystem[1]["label"] .. " exceeds threshold! Aborting request.")
                 return false
             end
         end

--- a/src/AE2.lua
+++ b/src/AE2.lua
@@ -3,13 +3,20 @@ local ME = component.me_interface
 
 local AE2 = {}
 
-function AE2.requestItem(name, count)
+function AE2.requestItem(name, threshold, count)
     craftables = ME.getCraftables({
         ["label"] = name
     })
 
     if #craftables >= 1 then
         item = craftables[1].getItemStack()
+        itemInSystem = ME.getItemsInNetwork({
+        	["label"] = name        
+        })
+        if (#itemInSystem > 0 and itemInSystem[1]["size"] > threshold) then 
+            print("The amount of " .. itemInSystem[1]["label"] .. " exceeds threshold! Aborting request.")
+            return false
+        end
         if item.label == name then
             local craft = craftables[1].request(count)
 

--- a/src/Utility.lua
+++ b/src/Utility.lua
@@ -29,5 +29,7 @@ function parser(string)
 end
 
 function logInfo(string)
-    print("[" .. os.date("%H:%M:%S") .. "] " .. string)
+    if type(string) == "string" then
+        print("[" .. os.date("%H:%M:%S") .. "] " .. string)
+    end
 end

--- a/src/Utility.lua
+++ b/src/Utility.lua
@@ -27,3 +27,7 @@ function parser(string)
         return 0
     end
 end
+
+function logInfo(string)
+    print("[" .. os.date("%H:%M:%S") .. "] " .. string)
+end


### PR DESCRIPTION
Lets the user set a threshold for every item, much like the ae2 level maintainer. existing configs require the following change:
Every item in `cfg["items"]` needs to be:
 `["item_name"] = {maintain_amount, batch_size}` instead of:
 `["item_name"] = batch_size`